### PR TITLE
Remove redundant find_package(OROCOS-RTT) call and fix orocos_generate_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,10 @@ project(rt_string_msgs)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  rtt_roscomm
   message_generation
   std_msgs
 )
-
-## Find Orocos RTT and plugins
-find_package(OROCOS-RTT 2.0.0 COMPONENTS rtt-scripting rtt-marshalling rtt-transport-corba)
-if (NOT OROCOS-RTT_FOUND)
-  message(FATAL_ERROR "\n   RTT not found. Is the version correct? Use the CMAKE_PREFIX_PATH cmake or environment variable to point to the installation directory of RTT.")
-else()
-  include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-  #add_definitions( -DRTT_COMPONENT )
-endif()
-
-## find catkin and catkin dependencies
-find_package(catkin REQUIRED COMPONENTS rtt_roscomm)
-catkin_destinations()
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,5 @@ install(
 
 ## Generate Orocos package
 orocos_generate_package(
-  DEPENDS rt_string_msgs
   DEPENDS_TARGETS rtt_roscomm
 )

--- a/package.xml
+++ b/package.xml
@@ -12,16 +12,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
-
   <build_export_depend>message_generation</build_export_depend>
-
   <exec_depend>message_runtime</exec_depend>
 
   <depend>rtt_roscomm</depend>
   <depend>std_msgs</depend>
-
-  <test_depend>roscpp_serialization</test_depend>
-  <test_depend>roscpp_traits</test_depend>
 
   <export>
     <rtt_ros>


### PR DESCRIPTION
RTT will be found implicitly by `find_package(catkin REQUIRED COMPONENTS rtt_roscomm)`.

See also related pull request https://github.com/orocos/rtt_kdl_msgs/pull/4 in https://github.com/orocos/rtt_kdl_msgs.