### PR TITLE
rt_string_msgs: fixed registration of ROS transport for rt_string

### DIFF
--- a/include/orocos/rt_string_msgs/boost/rt_string.h
+++ b/include/orocos/rt_string_msgs/boost/rt_string.h
@@ -1,14 +1,9 @@
 #ifndef RT_STRING_MSGS_BOOST_SERIALIZATION_RT_STRING_H
 #define RT_STRING_MSGS_BOOST_SERIALIZATION_RT_STRING_H
 
-#include <boost/serialization/serialization.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/string.hpp>
+// File needed because the generated typekits for derived message packages
+// unconditionally include rt_string_msgs/boost/rt_string.h
 
 #include <rt_string_msgs/rt_string.h>
-
-// File needed because the generated typekit rtt_rt_string_msgs 
-// unconditionally includes rt_string_msgs/boost/rt_string.h
 
 #endif // RT_STRING_MSGS_BOOST_SERIALIZATION_RT_STRING_H

--- a/src/ros_rt_string_msgs_transport.cpp
+++ b/src/ros_rt_string_msgs_transport.cpp
@@ -1,4 +1,4 @@
-#include <rt_string_msgs/boost/rt_string.h>
+#include <rt_string_msgs/rt_string.h>
 
 #include <rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp>
 #include <rtt_roscomm/rtt_rostopic.h>
@@ -12,7 +12,7 @@ namespace rtt_roscomm {
     {
       bool registerTransport(std::string name, types::TypeInfo* ti)
       {
-          if(name == "RTT.rt_string") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID,new RosMsgTransporter<RTT::rt_string>());} else
+          if(name == "rt_string") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<RTT::rt_string>());} else
             return false;
       }
       


### PR DESCRIPTION
The name of the type as registered in the RTT type system is `rt_string`, not `RTT.rt_string`.
See also https://github.com/orocos-toolchain/rtt/blob/master/rtt/typekit/RTStringTypeInfo.hpp.

The comment in the boost header was misleading. There is no `rtt_rt_string_msgs` typekit package because RTT already provides a typekit for rt_string and this package only adds a ROS transport plugin, that allows to stream rt_string ports to and from ROS topics, without any additional dependencies.